### PR TITLE
Adds a zlib decoder and encoder

### DIFF
--- a/src/trust/nccgroup/decoderimproved/DecodeMode.java
+++ b/src/trust/nccgroup/decoderimproved/DecodeMode.java
@@ -27,6 +27,7 @@ public class DecodeMode extends ModificationMode {
         decoders.add(new FuzzyBase64Decoder());
         decoders.add(new ASCIIHexDecoder());
         decoders.add(new GZIPDecoder());
+        decoders.add(new ZlibDecoder());
 
         // Swing Components
         decoderComboBox = new JComboBox<>();

--- a/src/trust/nccgroup/decoderimproved/EncodeMode.java
+++ b/src/trust/nccgroup/decoderimproved/EncodeMode.java
@@ -33,6 +33,7 @@ public class EncodeMode extends ModificationMode {
         encoders.add(new Base64UrlEncoder());
         encoders.add(new ASCIIHexEncoder());
         encoders.add(new GZIPEncoder());
+        encoders.add(new ZlibEncoder());
         //encoders.add(new FooBarEncoder());
 
         // Swing Components for displaying encoder names

--- a/src/trust/nccgroup/decoderimproved/ZlibDecoder.java
+++ b/src/trust/nccgroup/decoderimproved/ZlibDecoder.java
@@ -1,0 +1,35 @@
+package trust.nccgroup.decoderimproved;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.InflaterInputStream;
+import java.util.zip.ZipException;
+
+/**
+ * Created by webpentest on 05/2018.
+ */
+public class ZlibDecoder extends ByteModifier {
+    public ZlibDecoder() {
+        super("Zlib");
+    }
+
+    @Override
+    public byte[] modifyBytes(byte[] input) throws ModificationException {
+        try {
+            ByteArrayInputStream bais = new ByteArrayInputStream(input);
+            InflaterInputStream inflaterStream = new InflaterInputStream(bais);
+            byte[] buffer = new byte[input.length*2];
+            int bytesRead;
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            while ((bytesRead = inflaterStream.read(buffer, 0, buffer.length)) != -1) {
+                output.write(buffer, 0, bytesRead);
+            }
+            return output.toByteArray();
+        } catch (ZipException e){
+            throw new ModificationException("Invalid Zlib Input");
+        } catch (IOException e) {
+            throw new ModificationException("IO Error");
+        }
+    }
+}

--- a/src/trust/nccgroup/decoderimproved/ZlibEncoder.java
+++ b/src/trust/nccgroup/decoderimproved/ZlibEncoder.java
@@ -1,0 +1,29 @@
+package trust.nccgroup.decoderimproved;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.DeflaterOutputStream;
+
+public class ZlibEncoder  extends ByteModifier {
+    public ZlibEncoder() {
+        super("Zlib");
+    }
+
+    @Override
+    public byte[] modifyBytes(byte[] input) {
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream(input.length);
+            DeflaterOutputStream deflater = new DeflaterOutputStream(bos);
+            deflater.write(input, 0, input.length);
+            deflater.finish();
+            deflater.flush();
+            bos.flush();
+            deflater.close();
+            bos.close();
+            return bos.toByteArray();
+        } catch (IOException e) {
+            byte [] empty = {};
+            return empty;
+        }
+    }
+}


### PR DESCRIPTION
Decoder-improved already has gzip support, but there are
some cases (e.g. 3DSecure PaReq/PeRes) where data is deflated
with a zlib header instead of a gzip header.