### PR TITLE
Fix "Send to Decoder Improved" UTF-8 conversion character bug issue 4

### DIFF
--- a/src/trust/nccgroup/decoderimproved/MultiDecoderTab.java
+++ b/src/trust/nccgroup/decoderimproved/MultiDecoderTab.java
@@ -108,18 +108,10 @@ public class MultiDecoderTab extends JPanel implements ITab {
         return -1;
     }
 
-    public void receiveTextFromMenu(String selectedText) {
+    public void receiveTextFromMenu(byte[] selectedTextBytes) {
         // TODO: Add checks to see if the decoder segment is populated.
-        byte[] selectedTextBytes;
-        try {
-            selectedTextBytes = selectedText.getBytes("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            // This should never happen
-            selectedTextBytes = new byte[0];
-        }
         if (firstEmptyDecoder() == -1) {
             // Add a new tab
-
             addTab();
             DecoderTab dt = (DecoderTab) main.getComponentAt(main.getTabCount()-2);
             dt.getDecoderSegments().get(0).dsState.setByteArrayList(selectedTextBytes);

--- a/src/trust/nccgroup/decoderimproved/SendToDecoderImprovedContextMenuFactory.java
+++ b/src/trust/nccgroup/decoderimproved/SendToDecoderImprovedContextMenuFactory.java
@@ -5,6 +5,7 @@ import burp.*;
 import javax.swing.*;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -35,10 +36,10 @@ class SendToDecoderImprovedContextMenuFactory implements IContextMenuFactory {
                 int end = invocation.getSelectionBounds()[1];
                 //tab.receiveTextFromMenu(new String(requestResponses[0].getRequest(), "UTF-8").substring(start, end));
                 if (start == end) {
-                    tab.receiveTextFromMenu(UTF8StringEncoder.newUTF8String(requestResponses[0].getRequest()));
+                    tab.receiveTextFromMenu(requestResponses[0].getRequest());
                     Utils.highlightParentTab((JTabbedPane) tab.getUiComponent().getParent(), tab.getUiComponent());
                 } else {
-                    tab.receiveTextFromMenu(UTF8StringEncoder.newUTF8String(requestResponses[0].getRequest()).substring(start, end));
+                    tab.receiveTextFromMenu(Arrays.copyOfRange(requestResponses[0].getRequest(), start, end));
                     Utils.highlightParentTab((JTabbedPane) tab.getUiComponent().getParent(), tab.getUiComponent());
                 }
             };
@@ -50,10 +51,10 @@ class SendToDecoderImprovedContextMenuFactory implements IContextMenuFactory {
                 int start = invocation.getSelectionBounds()[0];
                 int end = invocation.getSelectionBounds()[1];
                 if (start == end) {
-                    tab.receiveTextFromMenu(UTF8StringEncoder.newUTF8String(requestResponses[0].getResponse()));
+                    tab.receiveTextFromMenu(requestResponses[0].getResponse());
                     Utils.highlightParentTab((JTabbedPane) tab.getUiComponent().getParent(), tab.getUiComponent());
                 } else {
-                    tab.receiveTextFromMenu(UTF8StringEncoder.newUTF8String(requestResponses[0].getResponse()).substring(start, end));
+                    tab.receiveTextFromMenu(Arrays.copyOfRange(requestResponses[0].getResponse(), start, end));
                     Utils.highlightParentTab((JTabbedPane) tab.getUiComponent().getParent(), tab.getUiComponent());
                 }
             };


### PR DESCRIPTION
Fix #4 

The original "Send to Decoder Improved" byte array is now directly sent to the decoder tab and saved in `byteArrayList`.