### PR TITLE
Fix item 1 and 3 of issue 16

### DIFF
--- a/src/trust/nccgroup/decoderimproved/DecoderSegmentState.java
+++ b/src/trust/nccgroup/decoderimproved/DecoderSegmentState.java
@@ -26,14 +26,14 @@ public class DecoderSegmentState {
 
 
     // Calculate byte offset based on UTF-8 multibyte definition, to support more multibyte characters.
-    // The text editor is still buggy dealing with random non-UTF-8 binary as it doesn't update UTF-8 encoded text in real time.
-    // calculateByteOffset_v1() also works in most cases, but for some weird strings it has different results.
-    // TODO: compare with calculateByteOffset_v1() and find the right way out
+    // The text editor is still buggy on showing the newly updated UTF-8 encoding result as the text won't be updated in real time.
     private int calculateByteOffset(int stringOffset) {
         byte[] bytes = getByteArray();
         int offset = 0;
         for (int i = 0; i < stringOffset; i++) {
             int cur = offset;
+            if (cur >= bytes.length)
+                break;
             byte b = bytes[cur];
             if (b >= 0) { // single-byte char, in 00000000 - 01111111
                 if (b == 13 && cur + 1 < bytes.length && bytes[cur + 1] == 10) { // CRLF \x0d\x0a case
@@ -65,32 +65,6 @@ public class DecoderSegmentState {
             }
         }
         return offset;
-    }
-
-    // Simplified the previous calculateByteOffset() (now calculateByteOffset_v0), removed replacement character logic
-    // because it's not needed due to direct copy of byte array during "Send to Decoder Improved" process.
-    // Added \x0d\x0a support
-    private int calculateByteOffset_v1(int startIndex) {
-        try {
-            String displayString = getDisplayString();
-            byte[] bytes = getByteArray();
-            // This is the total offset
-            int offset = 0;
-            // Iterate over the first 0 -> startIndex chars in displayString
-            for (int i = 0; i < startIndex; i++)  {
-                //  CRLF \x0d\x0a case
-                if (displayString.charAt(i) == 0x0d && i + 1 < displayString.length() && displayString.charAt(i + 1) == 0x0a) {
-                    offset += 2;
-                } else {
-                    byte[] characterBytes = displayString.substring(i, i + 1).getBytes("UTF-8");
-                    offset += characterBytes.length;
-                }
-            }
-            return offset;
-        } catch (UnsupportedEncodingException e) {
-            // this should never happen
-            return -1;
-        }
     }
 
     // This is a miracle that this works. If it causes an exception, sorry.

--- a/src/trust/nccgroup/decoderimproved/DecoderSegmentState.java
+++ b/src/trust/nccgroup/decoderimproved/DecoderSegmentState.java
@@ -21,17 +21,80 @@ public class DecoderSegmentState {
     }
 
     public String getDisplayString() {
-        // This is a bad way to do this but it works for now
-        // but I need to convert the Byte ArrayList back to a byte[] for new String()
-        byte[] output = new byte[byteArrayList.size()];
-        for (int i = 0; i < byteArrayList.size(); i++) {
-            output[i] = byteArrayList.get(i);
+        return UTF8StringEncoder.newUTF8String(getByteArray());
+    }
+
+
+    // Calculate byte offset based on UTF-8 multibyte definition, to support more multibyte characters.
+    // The text editor is still buggy dealing with random non-UTF-8 binary as it doesn't update UTF-8 encoded text in real time.
+    // calculateByteOffset_v1() also works in most cases, but for some weird strings it has different results.
+    // TODO: compare with calculateByteOffset_v1() and find the right way out
+    private int calculateByteOffset(int stringOffset) {
+        byte[] bytes = getByteArray();
+        int offset = 0;
+        for (int i = 0; i < stringOffset; i++) {
+            int cur = offset;
+            byte b = bytes[cur];
+            if (b >= 0) { // single-byte char, in 00000000 - 01111111
+                if (b == 13 && cur + 1 < bytes.length && bytes[cur + 1] == 10) { // CRLF \x0d\x0a case
+                    offset += 2;
+                } else {
+                    offset += 1;
+                }
+            } else if (b <= -33 && b >= -64) { // two-byte char, first byte in 11000000 - 11011111
+                // for multibyte chars, the second, third and fourth byte should in 10000000 - 10111111
+                for (int j = 0; j <= 1; j++) {
+                    if (cur + j < bytes.length && (j == 0 || bytes[cur + j] <= -65)) {
+                        offset++;
+                    }
+                }
+            } else if (b <= -17 && b >= -32) { // three-byte char, first byte in 11100000 - 11101111
+                for (int j = 0; j <= 2; j++) {
+                    if (cur + j < bytes.length && (j == 0 || bytes[cur + j] <= -65)) {
+                        offset++;
+                    }
+                }
+            } else if (b <= -9 && b >= -16) { // four-byte char, first byte in 11110000 - 11110111
+                for (int j = 0; j <= 3; j++) {
+                    if (cur + j < bytes.length && (j == 0 || bytes[cur + j] <= -65)) {
+                        offset++;
+                    }
+                }
+            } else { // Unknown byte
+                offset += 1;
+            }
         }
-        return UTF8StringEncoder.newUTF8String(output);
+        return offset;
+    }
+
+    // Simplified the previous calculateByteOffset() (now calculateByteOffset_v0), removed replacement character logic
+    // because it's not needed due to direct copy of byte array during "Send to Decoder Improved" process.
+    // Added \x0d\x0a support
+    private int calculateByteOffset_v1(int startIndex) {
+        try {
+            String displayString = getDisplayString();
+            byte[] bytes = getByteArray();
+            // This is the total offset
+            int offset = 0;
+            // Iterate over the first 0 -> startIndex chars in displayString
+            for (int i = 0; i < startIndex; i++)  {
+                //  CRLF \x0d\x0a case
+                if (displayString.charAt(i) == 0x0d && i + 1 < displayString.length() && displayString.charAt(i + 1) == 0x0a) {
+                    offset += 2;
+                } else {
+                    byte[] characterBytes = displayString.substring(i, i + 1).getBytes("UTF-8");
+                    offset += characterBytes.length;
+                }
+            }
+            return offset;
+        } catch (UnsupportedEncodingException e) {
+            // this should never happen
+            return -1;
+        }
     }
 
     // This is a miracle that this works. If it causes an exception, sorry.
-    private int calculateByteOffset(int startIndex) {
+    private int calculateByteOffset_v0(int startIndex) {
         // byte[] replacementChar = Charset.forName("UTF-8").newEncoder().replacement();
         // System.out.print("The Replacement is: ");
         // Utils.printByteArray(replacementChar);
@@ -129,7 +192,7 @@ public class DecoderSegmentState {
         // try {
         // I need to calculate the correct offsets based on the actual underlying bytes
         int deleteOffset = calculateByteOffset(offset);
-        int charsRemovedLength = calculateByteOffset(offset + length)-deleteOffset;
+        int charsRemovedLength = calculateByteOffset(offset + length) - deleteOffset;
         for (int i = 0; i < charsRemovedLength; i++) {
             byteArrayList.remove(deleteOffset);
         }

--- a/src/trust/nccgroup/decoderimproved/Logger.java
+++ b/src/trust/nccgroup/decoderimproved/Logger.java
@@ -1,6 +1,9 @@
 package trust.nccgroup.decoderimproved;
 
 import burp.IBurpExtenderCallbacks;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
@@ -21,6 +24,15 @@ public class Logger {
     public static void printError(String errorString){
         if (callbacks != null) {
             callbacks.printError("[" + getCurrentDateString() + "] " + errorString);
+        }
+    }
+
+    public static void printErrorFromException(Exception e) {
+        if (callbacks != null) {
+            StringWriter stringWriter = new StringWriter();
+            PrintWriter printWriter = new PrintWriter(stringWriter);
+            e.printStackTrace(printWriter);
+            callbacks.printError(stringWriter.toString());
         }
     }
 

--- a/src/trust/nccgroup/decoderimproved/MultiDecoderTab.java
+++ b/src/trust/nccgroup/decoderimproved/MultiDecoderTab.java
@@ -581,7 +581,7 @@ public class MultiDecoderTab extends JPanel implements ITab {
                 public void insertUpdate(DocumentEvent e) {
                     if (! lockDocumentEvents) {
                         // These events trigger when a user is doing regular typing into the text editor
-                        String insertedText = textEditor.getText().substring(e.getOffset(), e.getOffset() + e.getLength());
+                        String insertedText = textEditor.getText().replace("\r\n", "\n").substring(e.getOffset(), e.getOffset() + e.getLength());
                         dsState.insertUpdateIntoByteArrayList(insertedText, e.getOffset());
 
                         // Utils.printByteArray(dsState.getByteArray());

--- a/src/trust/nccgroup/decoderimproved/UTF8StringEncoder.java
+++ b/src/trust/nccgroup/decoderimproved/UTF8StringEncoder.java
@@ -17,7 +17,7 @@ public class UTF8StringEncoder {
         try {
             return utf8Decoder.decode(ByteBuffer.wrap(input)).toString();
         } catch (CharacterCodingException e) {
-            Utils.printByteArray(input);
+            System.out.println(Utils.convertByteArrayToHexString(input));
             return "";
         }
     }

--- a/src/trust/nccgroup/decoderimproved/Utils.java
+++ b/src/trust/nccgroup/decoderimproved/Utils.java
@@ -56,12 +56,12 @@ public class Utils {
     }
 
 
-    public static void printByteArray (byte[] data) {
+    public static String convertByteArrayToHexString (byte[] data) {
         StringBuilder sb = new StringBuilder();
         for (byte b : data) {
             sb.append(String.format("%02X ", b));
         }
-        System.out.println(sb.toString());
+        return sb.toString();
     }
 
     public static byte[] convertHexDataToByteArray(BinaryData data) {


### PR DESCRIPTION
CRLF `\x0d\x0a' doesn't seem to be a problem any more.