### PR TITLE
Export, import and clear tabs

### DIFF
--- a/src/trust/nccgroup/decoderimproved/ConfigPanel.java
+++ b/src/trust/nccgroup/decoderimproved/ConfigPanel.java
@@ -1,0 +1,82 @@
+package trust.nccgroup.decoderimproved;
+
+import javax.swing.*;
+import java.awt.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+
+public class ConfigPanel extends JPanel {
+    JButton exportButton;
+    JButton loadButton;
+    JToggleButton clearButton;
+
+    public ConfigPanel(ExtensionRoot extensionRoot) {
+        this.setLayout(new FlowLayout(FlowLayout.LEFT));
+        exportButton = new JButton("Export all tabs to file");
+        loadButton = new JButton("Load tabs from file");
+        String clearButtonText = "Clear all tabs on exit";
+        clearButton = new JToggleButton(clearButtonText);
+
+        this.add(exportButton);
+        this.add(loadButton);
+        this.add(clearButton);
+
+        // Listeners
+        exportButton.addActionListener((e) -> {
+            try {
+                JFileChooser fileChooser = new JFileChooser();
+                fileChooser.setDialogTitle("Save all data to...");
+                // Grab focus to save file dialog
+                fileChooser.addHierarchyListener((_event) -> {
+                    grabFocus();
+                });
+                if (fileChooser.showSaveDialog(extensionRoot.multiDecoderTab) == JFileChooser.APPROVE_OPTION) {
+                    FileOutputStream fileOutputStream = new FileOutputStream(fileChooser.getSelectedFile());
+                    // Get state and write to file
+                    fileOutputStream.write(extensionRoot.multiDecoderTab.getState().getBytes());
+                    fileOutputStream.close();
+                }
+            } catch (Exception ee) {
+                Logger.printErrorFromException(ee);
+            }
+        });
+
+        loadButton.addActionListener((e) -> {
+            try {
+                JFileChooser fileChooser = new JFileChooser();
+                fileChooser.setDialogTitle("Load data from...");
+                // Grab focus to load file dialog
+                fileChooser.addHierarchyListener((_event) -> {
+                    grabFocus();
+                });
+                if (fileChooser.showOpenDialog(extensionRoot.multiDecoderTab) == JFileChooser.APPROVE_OPTION) {
+                    // Read file content
+                    File selectedFile = fileChooser.getSelectedFile();
+                    FileInputStream fileInputStream = new FileInputStream(selectedFile);
+                    byte[] fileContent = new byte[(int) selectedFile.length()];
+                    fileInputStream.read(fileContent);
+                    fileInputStream.close();
+                    extensionRoot.multiDecoderTab.setState(new String(fileContent), false);
+                }
+            } catch (Exception ee) {
+                Logger.printErrorFromException(ee);
+                JOptionPane.showMessageDialog(extensionRoot.multiDecoderTab, ee.getClass().getName() + ", please check extension errors for details", "Error loading file", JOptionPane.ERROR_MESSAGE);
+            }
+        });
+
+        clearButton.addItemListener((e) -> {
+            try {
+                if (clearButton.isSelected()) {
+                    extensionRoot.setClearState();
+                    clearButton.setText("ALL TABS will be CLEARED on exit");
+                } else {
+                    extensionRoot.setSaveFullState();
+                    clearButton.setText(clearButtonText);
+                }
+            } catch (Exception ee) {
+                Logger.printErrorFromException(ee);
+            }
+        });
+    }
+}

--- a/src/trust/nccgroup/decoderimproved/ExtensionRoot.java
+++ b/src/trust/nccgroup/decoderimproved/ExtensionRoot.java
@@ -7,6 +7,8 @@ public class ExtensionRoot implements IBurpExtender {
     private IBurpExtenderCallbacks callbacks;
     private IExtensionHelpers helpers;
 
+    MultiDecoderTab multiDecoderTab;
+
     public void registerExtenderCallbacks(IBurpExtenderCallbacks _callbacks) {
 
         callbacks = _callbacks;
@@ -16,14 +18,25 @@ public class ExtensionRoot implements IBurpExtender {
 
         callbacks.setExtensionName("Decoder Improved");
 
-        MultiDecoderTab multiDecoderTab = new MultiDecoderTab(callbacks);
+        multiDecoderTab = new MultiDecoderTab(this);
         //callbacks.customizeUiComponent(multiDecoderTab);
         callbacks.addSuiteTab(multiDecoderTab);
-        callbacks.registerContextMenuFactory(new SendToDecoderImprovedContextMenuFactory(callbacks, multiDecoderTab));
+        callbacks.registerContextMenuFactory(new SendToDecoderImprovedContextMenuFactory(multiDecoderTab));
 
         String savedSettings = callbacks.loadExtensionSetting(multiDecoderTab.getTabCaption());
-        multiDecoderTab.setState(savedSettings);
+        // null state will be handled in MultiDecoderTab
+        multiDecoderTab.setState(savedSettings, true);
 
+        setSaveFullState();
+    }
+
+    public void setSaveFullState() {
+        callbacks.getExtensionStateListeners().forEach((x) -> callbacks.removeExtensionStateListener(x));
         callbacks.registerExtensionStateListener(() -> callbacks.saveExtensionSetting(multiDecoderTab.getTabCaption(), multiDecoderTab.getState()));
+    }
+
+    public void setClearState() {
+        callbacks.getExtensionStateListeners().forEach((x) -> callbacks.removeExtensionStateListener(x));
+        callbacks.registerExtensionStateListener(() -> callbacks.saveExtensionSetting(multiDecoderTab.getTabCaption(), null));
     }
 }

--- a/src/trust/nccgroup/decoderimproved/Logger.java
+++ b/src/trust/nccgroup/decoderimproved/Logger.java
@@ -2,6 +2,7 @@ package trust.nccgroup.decoderimproved;
 
 import burp.IBurpExtenderCallbacks;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.LocalDateTime;
@@ -29,10 +30,16 @@ public class Logger {
 
     public static void printErrorFromException(Exception e) {
         if (callbacks != null) {
-            StringWriter stringWriter = new StringWriter();
-            PrintWriter printWriter = new PrintWriter(stringWriter);
-            e.printStackTrace(printWriter);
-            callbacks.printError(stringWriter.toString());
+            try {
+                StringWriter stringWriter = new StringWriter();
+                PrintWriter printWriter = new PrintWriter(stringWriter);
+                e.printStackTrace(printWriter);
+                callbacks.printError(stringWriter.toString());
+                printWriter.close();
+                stringWriter.close();
+            } catch (IOException ee){
+                printError(ee.getMessage());
+            }
         }
     }
 

--- a/src/trust/nccgroup/decoderimproved/SendToDecoderImprovedContextMenuFactory.java
+++ b/src/trust/nccgroup/decoderimproved/SendToDecoderImprovedContextMenuFactory.java
@@ -12,13 +12,9 @@ import java.util.List;
  * Created by j on 12/9/16.
  */
 class SendToDecoderImprovedContextMenuFactory implements IContextMenuFactory {
-    private IBurpExtenderCallbacks callbacks;
-    private IExtensionHelpers helpers;
     private MultiDecoderTab tab;
 
-    public SendToDecoderImprovedContextMenuFactory(IBurpExtenderCallbacks _callbacks, MultiDecoderTab _tab) {
-        callbacks = _callbacks;
-        helpers = callbacks.getHelpers();
+    public SendToDecoderImprovedContextMenuFactory(MultiDecoderTab _tab) {
         tab = _tab;
     }
 


### PR DESCRIPTION
A panel is added at the bottom to offer the following functions:

- Export all tabs to a JSON file
- Import tabs from a JSON file
- Clear all tabs on exit / unloading the extension, implemented by setting `null` to the Burp extension state.

Fix #18 

**Note: The extension state is still shared by all temporary and disk-based projects. This is limited by the current version of Burp API having no way to save extension state to the project files. It can be enhanced once the API is provided by Burp.**
