### PR TITLE
Change of dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     compile group: 'org.exbin.deltahex', name: 'deltahex-swing', version: '0.1.3'
     compile group: 'org.exbin.utils', name: 'exbin-binary_data', version: '0.1.3-20171017.212506-7'
     compile group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.54'
+    compile group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
     //compile group: 'com.google.guava', name: 'guava', version: '+'
     //compile group: 'org.brotli', name: 'dec', version: '0.1.2'
     //compile group: 'org.brotli', name: 'parent', version: '0.1.2'

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     compile group: 'org.exbin.deltahex', name: 'deltahex-swing', version: '0.1.3'
     compile group: 'org.exbin.utils', name: 'exbin-binary_data', version: '0.1.3-20171017.212506-7'
     compile group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.54'
-    compile group: 'com.google.guava', name: 'guava', version: '+'
+    //compile group: 'com.google.guava', name: 'guava', version: '+'
     //compile group: 'org.brotli', name: 'dec', version: '0.1.2'
     //compile group: 'org.brotli', name: 'parent', version: '0.1.2'
     compile 'net.portswigger.burp.extender:burp-extender-api:2.1'

--- a/src/trust/nccgroup/decoderimproved/MultiDecoderTab.java
+++ b/src/trust/nccgroup/decoderimproved/MultiDecoderTab.java
@@ -1,7 +1,6 @@
 package trust.nccgroup.decoderimproved;
 
 import burp.ITab;
-import com.google.common.collect.Lists;
 import com.google.gson.*;
 import util.PDControlScrollPane;
 import org.exbin.utils.binary_data.ByteArrayEditableData;
@@ -351,7 +350,8 @@ public class MultiDecoderTab extends JPanel implements ITab {
         private void setupComponents() {
             scrollingBodyHolder = new JScrollPane();
             decoderTabBody = new JPanel();
-            decoderSegments = Lists.newArrayList(new DecoderSegment(this));
+            decoderSegments = new ArrayList<>();
+            decoderSegments.add(new DecoderSegment(this));
             this.setLayout(new BorderLayout());
             decoderTabBody.setLayout(new BoxLayout(decoderTabBody, BoxLayout.PAGE_AXIS));
 


### PR DESCRIPTION
- Removed `com.google.guava` that is only minorly used.
- Add `javax.xml.bind` to support building on Java 11. See [Java 11 release notes](https://www.oracle.com/technetwork/java/javase/11-relnote-issues-5012449.html#JDK-8190378) and [solution on StackOverflow](https://stackoverflow.com/a/43574427).