### PR TITLE
Fix issue 16, non-UTF-8 is mostly supported

### DIFF
--- a/src/trust/nccgroup/decoderimproved/ASCIIHexDecoder.java
+++ b/src/trust/nccgroup/decoderimproved/ASCIIHexDecoder.java
@@ -1,6 +1,7 @@
 package trust.nccgroup.decoderimproved;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import javax.xml.bind.DatatypeConverter;
 
 /**
@@ -14,11 +15,7 @@ public class ASCIIHexDecoder extends ByteModifier{
     // URL Encode the bytes
     public byte[] modifyBytes(byte[] input) throws ModificationException{
         String inputString;
-        try {
-            inputString = new String(input, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new ModificationException("Invalid Hex String");
-        }
+        inputString = new String(input, StandardCharsets.UTF_8);
         try {
             return DatatypeConverter.parseHexBinary(inputString);
         } catch (IllegalArgumentException e) {

--- a/src/trust/nccgroup/decoderimproved/ASCIIHexEncoder.java
+++ b/src/trust/nccgroup/decoderimproved/ASCIIHexEncoder.java
@@ -1,6 +1,7 @@
 package trust.nccgroup.decoderimproved;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Created by j on 12/6/16.
@@ -16,11 +17,7 @@ public class ASCIIHexEncoder extends ByteModifier {
         for (byte b : input) {
             output += String.format("%02X", (0xFF & (int)b));
         }
-        try {
-            return output.getBytes("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            return new byte[0];
-        }
+        return output.getBytes(StandardCharsets.UTF_8);
     }
 }
 

--- a/src/trust/nccgroup/decoderimproved/BaseConvertMode.java
+++ b/src/trust/nccgroup/decoderimproved/BaseConvertMode.java
@@ -6,6 +6,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
 /**
@@ -81,16 +82,12 @@ public class BaseConvertMode extends ModificationMode {
     }
 
     public byte[] modifyBytes(byte[] input) throws ModificationException {
+        String numericString = UTF8StringEncoder.newUTF8String(input);
         try {
-            String numericString = UTF8StringEncoder.newUTF8String(input);
-            try {
-                BigInteger convertedNumber = new BigInteger(numericString, fromBaseComboBox.getSelectedIndex() + 2);
-                String convertedNumberString = convertedNumber.toString(toBaseComboBox.getSelectedIndex() + 2);
-                return convertedNumberString.getBytes("UTF-8");
-            } catch (NumberFormatException e) {
-                throw new ModificationException("Invalid " + (String) fromBaseComboBox.getSelectedItem() + " Number");
-            }
-        } catch (UnsupportedEncodingException e) {
+            BigInteger convertedNumber = new BigInteger(numericString, fromBaseComboBox.getSelectedIndex() + 2);
+            String convertedNumberString = convertedNumber.toString(toBaseComboBox.getSelectedIndex() + 2);
+            return convertedNumberString.getBytes(StandardCharsets.UTF_8);
+        } catch (NumberFormatException e) {
             throw new ModificationException("Invalid " + (String) fromBaseComboBox.getSelectedItem() + " Number");
         }
     }

--- a/src/trust/nccgroup/decoderimproved/DecoderSegmentState.java
+++ b/src/trust/nccgroup/decoderimproved/DecoderSegmentState.java
@@ -1,6 +1,7 @@
 package trust.nccgroup.decoderimproved;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
 /**
@@ -44,16 +45,12 @@ public class DecoderSegmentState {
     public boolean insertUpdateIntoByteArrayList(String input, int offset) {
         // I turn the input string into bytes so I can correctly input all the bytes
         // then I add those bytes to byteArrayList
-        try {
-            byte[] inputBytes = input.getBytes("UTF-8");
-            int inputOffset = Utils.calculateByteOffset(getByteArray(), offset);
-            for (int i = 0; i < inputBytes.length; i++) {
-                byteArrayList.add(i + inputOffset, inputBytes[i]);
-            }
-            return true;
-        } catch (UnsupportedEncodingException e ) {
-            return false;
+        byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+        int inputOffset = Utils.calculateByteOffset(getByteArray(), offset);
+        for (int i = 0; i < inputBytes.length; i++) {
+            byteArrayList.add(i + inputOffset, inputBytes[i]);
         }
+        return true;
     }
 
     // This is for when the text editor is removing characters from the byteArrayList

--- a/src/trust/nccgroup/decoderimproved/DecoderSegmentState.java
+++ b/src/trust/nccgroup/decoderimproved/DecoderSegmentState.java
@@ -41,11 +41,11 @@ public class DecoderSegmentState {
                     offset += 1;
                 }
             } else if (b <= -33 && b >= -64) { // two-byte char, first byte in 11000000 - 11011111
-                offset += multibyteLength(bytes, cur, 1);
+                offset += multibyteOffset(bytes, cur, 1);
             } else if (b <= -17 && b >= -32) { // three-byte char, first byte in 11100000 - 11101111
-                offset += multibyteLength(bytes, cur, 2);
+                offset += multibyteOffset(bytes, cur, 2);
             } else if (b <= -9 && b >= -16) { // four-byte char, first byte in 11110000 - 11110111
-                offset += multibyteLength(bytes, cur, 3);
+                offset += multibyteOffset(bytes, cur, 3);
             } else { // Unsupported byte
                 offset += 1;
             }
@@ -53,20 +53,20 @@ public class DecoderSegmentState {
         return offset;
     }
 
-    private int multibyteLength(byte[] bytes, int currentOffset, int maxLength) {
-        int byteNumber = 0;
+    private int multibyteOffset(byte[] bytes, int currentOffset, int maxLength) {
+        int byteCount = 0;
         List<Byte> buf = new ArrayList<>();
         for (int j = 0; j <= maxLength; j++) {
             // the second (or third and fourth) byte should in 10000000 - 10111111
             if (currentOffset + j < bytes.length && (j == 0 || bytes[currentOffset + j] <= -65)) {
-                byteNumber += 1;
+                byteCount += 1;
                 buf.add(bytes[currentOffset + j]);
             } else {
                 break;
             }
         }
-        int characterNumber = UTF8StringEncoder.newUTF8String(Utils.convertByteArrayListToByteArray(buf)).length();
-        return byteNumber - characterNumber + 1;
+        int characterCount = UTF8StringEncoder.newUTF8String(Utils.convertByteArrayListToByteArray(buf)).length();
+        return byteCount - characterCount + 1;
     }
 
     // This is for when the text editor is updating the decoder segment state

--- a/src/trust/nccgroup/decoderimproved/DecoderSegmentState.java
+++ b/src/trust/nccgroup/decoderimproved/DecoderSegmentState.java
@@ -2,8 +2,6 @@ package trust.nccgroup.decoderimproved;
 
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * Created by j on 10/10/16.
@@ -25,75 +23,6 @@ public class DecoderSegmentState {
         return UTF8StringEncoder.newUTF8String(getByteArray());
     }
 
-    // Calculate byte offset based on UTF-8 multibyte definition, to support more multibyte characters.
-    private int calculateByteOffset(int stringOffset) {
-        byte[] bytes = getByteArray();
-        int offset = 0;
-        for (int i = 0; i < stringOffset; i++) {
-            int cur = offset;
-            if (cur >= bytes.length)
-                break;
-            byte b = bytes[cur];
-            if (b >= 0) { // single-byte char, in 00000000 - 01111111
-                if (b == 13 && cur + 1 < bytes.length && bytes[cur + 1] == 10) { // CRLF \x0d\x0a case
-                    offset += 2;
-                } else {
-                    offset += 1;
-                }
-            } else if (b <= -33 && b >= -64) { // two-byte char, first byte in 11000000 - 11011111
-                offset += multibyteOffset(bytes, cur, 1);
-            } else if (b <= -17 && b >= -32) { // three-byte char, first byte in 11100000 - 11101111
-                offset += multibyteOffset(bytes, cur, 2);
-            } else if (b <= -9 && b >= -16) { // four-byte char, first byte in 11110000 - 11110111
-                offset += multibyteOffset(bytes, cur, 3);
-            } else { // Unsupported byte
-                offset += 1;
-            }
-        }
-        return offset;
-    }
-
-    private int multibyteOffset(byte[] bytes, int currentOffset, int maxLength) {
-        int byteCount = 0;
-        List<Byte> buf = new ArrayList<>();
-        for (int j = 0; j <= maxLength; j++) {
-            // the second (or third and fourth) byte should in 10000000 - 10111111
-            if (currentOffset + j < bytes.length && (j == 0 || bytes[currentOffset + j] <= -65)) {
-                byteCount += 1;
-                buf.add(bytes[currentOffset + j]);
-            } else {
-                break;
-            }
-        }
-        int characterCount = UTF8StringEncoder.newUTF8String(Utils.convertByteArrayListToByteArray(buf)).length();
-        return byteCount - characterCount + 1;
-    }
-
-    // This is for when the text editor is updating the decoder segment state
-    public boolean insertUpdateIntoByteArrayList(String input, int offset) {
-        // I turn the input string into bytes so I can correctly input all the bytes
-        // then I add those bytes to byteArrayList
-        // System.out.print("The Byte offset is: ");
-        // System.out.println(calculateByteOffset(offset));
-        try {
-            byte[] inputBytes = input.getBytes("UTF-8");
-            //int inputOffset = getDisplayString().substring(0, offset).getBytes("UTF-8").length;
-            //int inputOffset = calculateByteOffset(0, offset);
-            int inputOffset = calculateByteOffset(offset);
-            // System.out.print("The offset is: ");
-            // System.out.println(offset);
-            // System.out.print("The inputOffset is: ");
-            // System.out.println(inputOffset);
-            for (int i = 0; i < inputBytes.length; i++) {
-                // System.out.println(input.charAt(i));
-                byteArrayList.add(i + inputOffset, inputBytes[i]);
-            }
-            return true;
-        } catch (UnsupportedEncodingException e ) {
-            return false;
-        }
-    }
-
     public byte[] getByteArray() {
         return Utils.convertByteArrayListToByteArray(byteArrayList);
     }
@@ -111,6 +40,22 @@ public class DecoderSegmentState {
         }
     }
 
+    // This is for when the text editor is updating the decoder segment state
+    public boolean insertUpdateIntoByteArrayList(String input, int offset) {
+        // I turn the input string into bytes so I can correctly input all the bytes
+        // then I add those bytes to byteArrayList
+        try {
+            byte[] inputBytes = input.getBytes("UTF-8");
+            int inputOffset = Utils.calculateByteOffset(getByteArray(), offset);
+            for (int i = 0; i < inputBytes.length; i++) {
+                byteArrayList.add(i + inputOffset, inputBytes[i]);
+            }
+            return true;
+        } catch (UnsupportedEncodingException e ) {
+            return false;
+        }
+    }
+
     // This is for when the text editor is removing characters from the byteArrayList
     public void removeUpdateFromByteArrayList(int offset, int length) {
         // So this chunk of code gets the substring that was removed
@@ -118,8 +63,9 @@ public class DecoderSegmentState {
         // to keep this update in sync with byteArrayList
         // try {
         // I need to calculate the correct offsets based on the actual underlying bytes
-        int deleteOffset = calculateByteOffset(offset);
-        int charsRemovedLength = calculateByteOffset(offset + length) - deleteOffset;
+        byte[] byteArray = getByteArray();
+        int deleteOffset = Utils.calculateByteOffset(byteArray, offset);
+        int charsRemovedLength = Utils.calculateByteOffset(byteArray, offset + length) - deleteOffset;
         for (int i = 0; i < charsRemovedLength; i++) {
             byteArrayList.remove(deleteOffset);
         }

--- a/src/trust/nccgroup/decoderimproved/FindAndReplaceMode.java
+++ b/src/trust/nccgroup/decoderimproved/FindAndReplaceMode.java
@@ -42,9 +42,9 @@ public class FindAndReplaceMode extends ModificationMode {
 
         regexBoxPanel = new JPanel();
         regexBoxPanel.setLayout(new BoxLayout(regexBoxPanel, BoxLayout.LINE_AXIS));
-        regexBoxPanel.setMaximumSize(new Dimension(180, 25));
-        regexBoxPanel.setMinimumSize(new Dimension(180, 25));
-        regexBoxPanel.setPreferredSize(new Dimension(180, 25));
+        regexBoxPanel.setMaximumSize(new Dimension(180, 30));
+        regexBoxPanel.setMinimumSize(new Dimension(180, 30));
+        regexBoxPanel.setPreferredSize(new Dimension(180, 30));
 
         regexLabel = new JLabel("Regex: ");
         regexTextField = new JTextField();
@@ -57,9 +57,9 @@ public class FindAndReplaceMode extends ModificationMode {
 
         replaceBoxPanel = new JPanel();
         replaceBoxPanel.setLayout(new BoxLayout(replaceBoxPanel, BoxLayout.LINE_AXIS));
-        replaceBoxPanel.setMaximumSize(new Dimension(180, 25));
-        replaceBoxPanel.setMinimumSize(new Dimension(180, 25));
-        replaceBoxPanel.setPreferredSize(new Dimension(180, 25));
+        replaceBoxPanel.setMaximumSize(new Dimension(180, 30));
+        replaceBoxPanel.setMinimumSize(new Dimension(180, 30));
+        replaceBoxPanel.setPreferredSize(new Dimension(180, 30));
 
         replaceBoxPanel.add(replaceLabel);
         replaceBoxPanel.add(replaceTextField);
@@ -78,14 +78,19 @@ public class FindAndReplaceMode extends ModificationMode {
 
     // There's a limitation here. Invalid UTF-8 bytes will be replaced by the replacement char in the result.
     public byte[] modifyBytes(byte[] input) throws ModificationException {
+        String regexText = regexTextField.getText();
+        if (regexText == null || regexText.isEmpty()) {
+            return input;
+        }
         // Do this first to make sure the regex is valid
         try {
-            Pattern.compile(regexTextField.getText());
+            Pattern.compile(regexText);
         } catch (PatternSyntaxException e) {
-            throw new ModificationException(regexTextField.getText() + " Is Not A Valid Regular Expression.");
+            throw new ModificationException(regexText + " Is Not A Valid Regular Expression.");
         }
         // Do this to make sure the input is a valid string
         // Find and replace doesn't work correctly on strings containing binary data
+        /* fixme: I didn't notice error when replacing a string that contains non-UTF-8 chars - fix me if anything is wrong
         try {
             CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
             decoder.onUnmappableCharacter(CodingErrorAction.REPORT);
@@ -93,16 +98,16 @@ public class FindAndReplaceMode extends ModificationMode {
             decoder.decode(ByteBuffer.wrap(input));
         } catch (Exception e) {
             throw new ModificationException("Invalid input. Find and Replace does not accept strings that contain non-UTF-8 characters.");
-        }
+        }*/
         if ((replaceComboBox.getSelectedItem()).equals("Replace First")) {
             //String inputString = new String(input, "UTF-8");
             String inputString = UTF8StringEncoder.newUTF8String(input);
-            inputString = inputString.replaceFirst(regexTextField.getText(), replaceTextField.getText());
+            inputString = inputString.replaceFirst(regexText, replaceTextField.getText());
             return inputString.getBytes(StandardCharsets.UTF_8);
         } else if ((replaceComboBox.getSelectedItem()).equals("Replace All")) {
             //String inputString = new String(input, "UTF-8");
             String inputString = UTF8StringEncoder.newUTF8String(input);
-            inputString = inputString.replaceAll(regexTextField.getText(), replaceTextField.getText());
+            inputString = inputString.replaceAll(regexText, replaceTextField.getText());
             return inputString.getBytes(StandardCharsets.UTF_8);
         }
         return new byte[0];

--- a/src/trust/nccgroup/decoderimproved/FindAndReplaceMode.java
+++ b/src/trust/nccgroup/decoderimproved/FindAndReplaceMode.java
@@ -9,6 +9,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -86,7 +87,7 @@ public class FindAndReplaceMode extends ModificationMode {
         // Do this to make sure the input is a valid string
         // Find and replace doesn't work correctly on strings containing binary data
         try {
-            CharsetDecoder decoder = Charset.forName("UTF-8").newDecoder();
+            CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
             decoder.onUnmappableCharacter(CodingErrorAction.REPORT);
             decoder.onMalformedInput(CodingErrorAction.REPORT);
             decoder.decode(ByteBuffer.wrap(input));
@@ -94,25 +95,15 @@ public class FindAndReplaceMode extends ModificationMode {
             throw new ModificationException("Invalid input. Find and Replace does not accept strings that contain non-UTF-8 characters.");
         }
         if ((replaceComboBox.getSelectedItem()).equals("Replace First")) {
-            try {
-                //String inputString = new String(input, "UTF-8");
-                String inputString = UTF8StringEncoder.newUTF8String(input);
-                inputString = inputString.replaceFirst(regexTextField.getText(), replaceTextField.getText());
-                return inputString.getBytes("UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                // This should never happen
-                throw new ModificationException("Invalid Input");
-            }
+            //String inputString = new String(input, "UTF-8");
+            String inputString = UTF8StringEncoder.newUTF8String(input);
+            inputString = inputString.replaceFirst(regexTextField.getText(), replaceTextField.getText());
+            return inputString.getBytes(StandardCharsets.UTF_8);
         } else if ((replaceComboBox.getSelectedItem()).equals("Replace All")) {
-            try {
-                //String inputString = new String(input, "UTF-8");
-                String inputString = UTF8StringEncoder.newUTF8String(input);
-                inputString = inputString.replaceAll(regexTextField.getText(), replaceTextField.getText());
-                return inputString.getBytes("UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                // This should never happen
-                throw new ModificationException("Invalid input");
-            }
+            //String inputString = new String(input, "UTF-8");
+            String inputString = UTF8StringEncoder.newUTF8String(input);
+            inputString = inputString.replaceAll(regexTextField.getText(), replaceTextField.getText());
+            return inputString.getBytes(StandardCharsets.UTF_8);
         }
         return new byte[0];
     }

--- a/src/trust/nccgroup/decoderimproved/FuzzyBase64Decoder.java
+++ b/src/trust/nccgroup/decoderimproved/FuzzyBase64Decoder.java
@@ -5,6 +5,7 @@ package trust.nccgroup.decoderimproved;
  */
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.regex.Matcher;
@@ -24,11 +25,7 @@ public class FuzzyBase64Decoder extends ByteModifier {
         input = Utils.convertUrlBase64ToStandard(input);
 
         String inputString;
-        try {
-            inputString = new String(input, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new ModificationException("Input Contains Non-Encodeable Characters");
-        }
+        inputString = new String(input, StandardCharsets.UTF_8);
         Pattern p = Pattern.compile("(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})");
         Matcher m = p.matcher(inputString);
         ArrayList<Byte> output = new ArrayList<>();

--- a/src/trust/nccgroup/decoderimproved/HTMLSpecialCharEncoder.java
+++ b/src/trust/nccgroup/decoderimproved/HTMLSpecialCharEncoder.java
@@ -1,10 +1,7 @@
 package trust.nccgroup.decoderimproved;
 
-import java.io.UnsupportedEncodingException;
-import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
-import java.nio.charset.CharsetDecoder;
-import java.nio.charset.CodingErrorAction;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by j on 1/6/17.
@@ -13,13 +10,14 @@ import java.nio.charset.CodingErrorAction;
 public class HTMLSpecialCharEncoder extends ByteModifier {
     String HTML_ENCODED_FORMAT_STRING = "&#%d;";
     char[] SPECIAL_CHARS = {'"', '\'', '&', '<', '>'};
+
     public HTMLSpecialCharEncoder() {
         super("HTML Special Characters");
     }
 
-    private boolean isSpecialChar(char input) {
+    private boolean isSpecialChar(byte b) {
         for (char c : SPECIAL_CHARS) {
-            if (c == input) {
+            if (b == c) {
                 return true;
             }
         }
@@ -27,34 +25,18 @@ public class HTMLSpecialCharEncoder extends ByteModifier {
     }
 
     // URL Encode the bytes
-    public byte[] modifyBytes(byte[] input) throws ModificationException{
-        StringBuilder output = new StringBuilder();
-        try {
-            CharsetDecoder decoder = Charset.forName("UTF-8").newDecoder();
-            decoder.onUnmappableCharacter(CodingErrorAction.REPORT);
-            decoder.onMalformedInput(CodingErrorAction.REPORT);
-            decoder.decode(ByteBuffer.wrap(input));
-
-            // String displayString = new String(input, "UTF-8");
-            String displayString = UTF8StringEncoder.newUTF8String(input);
-
-            for (int i = 0; i < displayString.length(); i++) {
-                if (isSpecialChar(displayString.charAt(i))) {
-                    int charCodePoint = Character.codePointAt(displayString, i);
-                    output.append(String.format(HTML_ENCODED_FORMAT_STRING, charCodePoint));
-                } else {
-                    output.append(displayString.charAt(i));
+    public byte[] modifyBytes(byte[] input) throws ModificationException {
+        List<Byte> output = new ArrayList<>(input.length);
+        for (byte b : input) {
+            if (isSpecialChar(b)) {
+                for (byte _b : String.format(HTML_ENCODED_FORMAT_STRING, (int) b).getBytes()) {
+                    output.add(_b);
                 }
+            } else {
+                output.add(b);
             }
-
-        } catch (Exception e) {
-            throw new ModificationException("Invalid input. HTML encoding does not accept strings that contain non-UTF-8 characters.");
         }
-        try {
-            return output.toString().getBytes("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new ModificationException("Invalid output");
-        }
+        return Utils.convertByteArrayListToByteArray(output);
     }
 }
 

--- a/src/trust/nccgroup/decoderimproved/HTMLSpecialCharEncoder.java
+++ b/src/trust/nccgroup/decoderimproved/HTMLSpecialCharEncoder.java
@@ -1,5 +1,6 @@
 package trust.nccgroup.decoderimproved;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,7 +30,7 @@ public class HTMLSpecialCharEncoder extends ByteModifier {
         List<Byte> output = new ArrayList<>(input.length);
         for (byte b : input) {
             if (isSpecialChar(b)) {
-                for (byte _b : String.format(HTML_ENCODED_FORMAT_STRING, (int) b).getBytes()) {
+                for (byte _b : String.format(HTML_ENCODED_FORMAT_STRING, (int) b).getBytes(StandardCharsets.UTF_8)) {
                     output.add(_b);
                 }
             } else {

--- a/src/trust/nccgroup/decoderimproved/JsPrettifier.java
+++ b/src/trust/nccgroup/decoderimproved/JsPrettifier.java
@@ -6,6 +6,7 @@ import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 //import org.graalvm.polyglot.*;
 
 public class JsPrettifier extends ByteModifier{
@@ -31,9 +32,9 @@ public class JsPrettifier extends ByteModifier{
     @Override
     public byte[] modifyBytes(byte[] input) throws ModificationException {
         try {
-            String pretty =  (String) ((Invocable) engine).invokeFunction(BEAUTIFY_METHOD_NAME, new String(input, "UTF-8"));
-            return pretty.getBytes("UTF-8");
-        } catch (ScriptException | NoSuchMethodException | UnsupportedEncodingException e) {
+            String pretty =  (String) ((Invocable) engine).invokeFunction(BEAUTIFY_METHOD_NAME, new String(input, StandardCharsets.UTF_8));
+            return pretty.getBytes(StandardCharsets.UTF_8);
+        } catch (ScriptException | NoSuchMethodException e) {
             throw new ModificationException("Failed to prettify JS");
         }
     }

--- a/src/trust/nccgroup/decoderimproved/MultiDecoderTab.java
+++ b/src/trust/nccgroup/decoderimproved/MultiDecoderTab.java
@@ -407,11 +407,11 @@ public class MultiDecoderTab extends JPanel implements ITab {
                 nextDecoderSegment.dsState.setByteArrayList(activeDecoderSegment.modes.modifyBytes(activeDsBytes));
                 nextDecoderSegment.updateEditors(nextDecoderSegment.dsState);
                 try {
-                    CharsetDecoder decoder = Charset.forName("UTF-8").newDecoder();
+                    CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
                     decoder.onUnmappableCharacter(CodingErrorAction.REPORT);
                     decoder.onMalformedInput(CodingErrorAction.REPORT);
                     decoder.decode(ByteBuffer.wrap(nextDecoderSegment.dsState.getByteArray()));
-                    new String(nextDecoderSegment.dsState.getByteArray(), "UTF-8");
+                    new String(nextDecoderSegment.dsState.getByteArray(), StandardCharsets.UTF_8);
                     // new UTF.newUTF8String(nextDecoderSegment.dsState.getByteArray());
                     //nextDecoderSegment.displayTextEditor(); // This is commented out as it sometimes got the extension frozen during loading settings, FIXME if anything wrong happens because of this
                 } catch (Exception e) {

--- a/src/trust/nccgroup/decoderimproved/URLEncoder.java
+++ b/src/trust/nccgroup/decoderimproved/URLEncoder.java
@@ -1,6 +1,7 @@
 package trust.nccgroup.decoderimproved;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Created by j on 12/6/16.
@@ -18,11 +19,6 @@ public class URLEncoder extends ByteModifier {
             output += "%";
             output += String.format("%02X", (0xFF & (int)b));
         }
-        try {
-            return output.getBytes("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-			// This should never happen
-            throw new ModificationException("Invalid Input");
-        }
+        return output.getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/src/trust/nccgroup/decoderimproved/URLSpecialCharEncoder.java
+++ b/src/trust/nccgroup/decoderimproved/URLSpecialCharEncoder.java
@@ -1,6 +1,7 @@
 package trust.nccgroup.decoderimproved;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Created by j on 12/6/16.
@@ -12,24 +13,20 @@ public class URLSpecialCharEncoder extends ByteModifier {
 
     // URL Encode the bytes
     public byte[] modifyBytes(byte[] input) {
-        try {
-            String letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-            String numbers = "0123456789";
-            String specialChars = "$-_.+!*'(),,";
-            byte[] whitelist = (letters + numbers + specialChars).getBytes("UTF-8");
+        String letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        String numbers = "0123456789";
+        String specialChars = "$-_.+!*'(),,";
+        byte[] whitelist = (letters + numbers + specialChars).getBytes(StandardCharsets.UTF_8);
 
-            String output = "";
-            for (byte b : input) {
-                if (!Utils.contains(whitelist, b)) {
-                    output += "%";
-                    output += String.format("%02X", (0xFF & (int) b));
-                } else {
-                    output += (char)b;
-                }
+        String output = "";
+        for (byte b : input) {
+            if (!Utils.contains(whitelist, b)) {
+                output += "%";
+                output += String.format("%02X", (0xFF & (int) b));
+            } else {
+                output += (char)b;
             }
-            return output.getBytes("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            return new byte[0];
         }
+        return output.getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/src/trust/nccgroup/decoderimproved/UTF8StringEncoder.java
+++ b/src/trust/nccgroup/decoderimproved/UTF8StringEncoder.java
@@ -1,4 +1,5 @@
 package trust.nccgroup.decoderimproved;
+
 import java.nio.ByteBuffer;
 import java.nio.charset.*;
 
@@ -7,7 +8,7 @@ import java.nio.charset.*;
  */
 public class UTF8StringEncoder {
     //private final static  replacementChar = {(byte)0xEF, (byte)0xBF, (byte)0xBD};
-    private final static CharsetDecoder utf8Decoder = Charset.forName("UTF-8")
+    private final static CharsetDecoder utf8Decoder = StandardCharsets.UTF_8
             .newDecoder()
             .replaceWith("�")
             .onMalformedInput(CodingErrorAction.REPLACE)
@@ -17,7 +18,7 @@ public class UTF8StringEncoder {
         try {
             return utf8Decoder.decode(ByteBuffer.wrap(input)).toString();
         } catch (CharacterCodingException e) {
-            System.out.println(Utils.convertByteArrayToHexString(input));
+            Logger.printErrorFromException(e);
             return "";
         }
     }

--- a/src/util/HexDump.java
+++ b/src/util/HexDump.java
@@ -5,6 +5,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 public class HexDump {
 
@@ -55,7 +56,7 @@ public class HexDump {
       width = Math.min(width, bytes.length - index);
       System.out.println(
           ":"
-              + new String(bytes, index, width, "UTF-8").replaceAll("\r\n", " ").replaceAll(
+              + new String(bytes, index, width, StandardCharsets.UTF_8).replaceAll("\r\n", " ").replaceAll(
               "\n",
               " "));
     } else {


### PR DESCRIPTION
Fix #16. The following modes now support non-UTF-8 characters:

- HTML encode
- HTML encode special characters
- HTML decode (added in previous commits)
- Find and replace (**might** have bugs)